### PR TITLE
If master doesnt support IPv4/IPv6, but slave does

### DIFF
--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -1103,6 +1103,16 @@ To notify all IP addresses apart from the 192.168.0.0/24 subnet use the followin
   explicitly using :ref:`setting-also-notify` and/or
   :ref:`metadata-also-notify` domain metadata to avoid this potential bottleneck.
 
+.. note::
+  If your slaves support Internet Protocol version, which your master does not, 
+  then set ``only-notify`` to include only supported protocol version. 
+  Otherwise there will be error trying to resolve address.
+  
+  For example, slaves support both IPv4 and IPv6, but PowerDNS master have only IPv4, 
+  so allow only IPv4 with ``only-notify``::
+  
+    only-notify=0.0.0.0/0
+
 .. _setting-out-of-zone-additional-processing:
 
 ``out-of-zone-additional-processing``


### PR DESCRIPTION
### Short description
Documentation update, added a note about correct configuration when master does not support either IPv4 or IPv6, but slave does.
Closes https://github.com/PowerDNS/pdns/issues/5899

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled this code
- [x] tested this code
- [x] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
